### PR TITLE
Switch from Ergast to Jolpica F1 API

### DIFF
--- a/components/predictions/Form.vue
+++ b/components/predictions/Form.vue
@@ -80,7 +80,7 @@ const emit = defineEmits<{
   submit: [prediction: Prediction]
 }>()
 
-const { fetchDriverStandings } = useErgastApi()
+const { fetchDriverStandings } = useJolpicaApi()
 const { fetchCurrentSeasonRaces } = useRaceData()
 
 const currentDrivers = ref([])

--- a/components/predictions/PredictionForm.vue
+++ b/components/predictions/PredictionForm.vue
@@ -80,7 +80,7 @@ const emit = defineEmits<{
   submit: [prediction: Prediction]
 }>()
 
-const { fetchDriverStandings } = useErgastApi()
+const { fetchDriverStandings } = useJolpicaApi()
 const { fetchCurrentSeasonRaces } = useRaceData()
 
 const currentDrivers = ref([])

--- a/composables/useJolpicaApi.ts
+++ b/composables/useJolpicaApi.ts
@@ -1,6 +1,6 @@
 import type { Driver, Constructor, Race, QualifyingResult, SprintResult } from '~/types/f1'
 
-export const useErgastApi = () => {
+export const useJolpicaApi = () => {
   const config = useRuntimeConfig()
   const currentYear = new Date().getFullYear()
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -6,7 +6,7 @@ export default defineNuxtConfig({
   ssr: false, // Disable SSR since we're using Firebase Auth
   runtimeConfig: {
     public: {
-      apiBase: 'https://ergast.com/api/f1'
+      apiBase: 'https://api.jolpi.ca/ergast/f1'
     }
   },
   app: {

--- a/pages/chat/index.vue
+++ b/pages/chat/index.vue
@@ -58,8 +58,8 @@ const rooms = ref<ChatRoom[]>([
 // Add driver and constructor rooms
 onMounted(async () => {
   const [drivers, constructors] = await Promise.all([
-    useErgastApi().fetchDriverStandings(),
-    useErgastApi().fetchConstructorStandings()
+    useJolpicaApi().fetchDriverStandings(),
+    useJolpicaApi().fetchConstructorStandings()
   ])
 
   // Add driver rooms

--- a/pages/compare/drivers.vue
+++ b/pages/compare/drivers.vue
@@ -145,7 +145,7 @@ const raceLabels = ref<string[]>([])
 const driver1Points = ref<number[]>([])
 const driver2Points = ref<number[]>([])
 
-const { fetchDriverStandings } = useErgastApi()
+const { fetchDriverStandings } = useJolpicaApi()
 
 // Charger la liste des pilotes disponibles
 onMounted(async () => {

--- a/pages/races/[year]/[round].vue
+++ b/pages/races/[year]/[round].vue
@@ -42,7 +42,7 @@ import type { Race } from '~/types/f1'
 
 const route = useRoute()
 const { generateMeta } = useSeo()
-const { fetchRaceResults, fetchQualifyingResults, fetchSprintResults } = useErgastApi()
+const { fetchRaceResults, fetchQualifyingResults, fetchSprintResults } = useJolpicaApi()
 
 const loading = ref(true)
 const race = ref<Race | null>(null)

--- a/pages/standings.vue
+++ b/pages/standings.vue
@@ -46,7 +46,7 @@
 </template>
 
 <script setup lang="ts">
-const { fetchDriverStandings, fetchConstructorStandings } = useErgastApi()
+const { fetchDriverStandings, fetchConstructorStandings } = useJolpicaApi()
 const currentYear = new Date().getFullYear()
 
 const loading = ref(false)

--- a/pages/stats.vue
+++ b/pages/stats.vue
@@ -110,7 +110,7 @@
 </template>
 
 <script setup lang="ts">
-const { fetchDriverStandings, fetchConstructorStandings } = useErgastApi()
+const { fetchDriverStandings, fetchConstructorStandings } = useJolpicaApi()
 const loading = ref(true)
 const drivers = ref([])
 const constructors = ref([])


### PR DESCRIPTION
## Summary
- migrate runtime API base to Jolpica service
- replace Ergast API composable with Jolpica version and update consumers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a56c082d44832cb4f91ae21b98424f