### PR TITLE
feat: apply f1 color palette to dashboard

### DIFF
--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -1,10 +1,10 @@
 <template>
-    <div class="min-h-screen bg-[#1a1b1f] text-white">
+    <div class="min-h-screen bg-f1-black text-white">
       <div class="max-w-7xl mx-auto px-4 py-8">
         <!-- Header -->
         <div class="flex items-center justify-between mb-8">
           <div>
-            <h1 class="text-3xl font-bold tracking-tight">F1 Dashboard</h1>
+            <h1 class="text-3xl font-bold tracking-tight text-f1-red">F1 Dashboard</h1>
             <p class="text-zinc-400">Données en direct via l'API Jolpica — saison en cours</p>
           </div>
           <div class="flex items-center gap-2 text-zinc-300">
@@ -16,10 +16,10 @@
   
         <!-- KPI Row -->
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-          <KpiCard title="Courses disputées" :value="racesCompleted" :subtitle="'Sur ' + totalRounds + ' prévues'" tone="emerald" />
-          <KpiCard title="Prochaine course" :value="nextRace?.raceName || '—'" :subtitle="nextRaceSubtitle" tone="cyan" />
-          <KpiCard title="Leader pilotes" :value="topDriver?.Driver?.familyName || '—'" :subtitle="(topDriver?.points || 0) + ' pts'" tone="violet" />
-          <KpiCard title="Leader écuries" :value="topTeam?.Constructor?.name || '—'" :subtitle="(topTeam?.points || 0) + ' pts'" tone="lime" />
+          <KpiCard title="Courses disputées" :value="racesCompleted" :subtitle="'Sur ' + totalRounds + ' prévues'" tone="green" />
+          <KpiCard title="Prochaine course" :value="nextRace?.raceName || '—'" :subtitle="nextRaceSubtitle" tone="yellow" />
+          <KpiCard title="Leader pilotes" :value="topDriver?.Driver?.familyName || '—'" :subtitle="(topDriver?.points || 0) + ' pts'" tone="red" />
+          <KpiCard title="Leader écuries" :value="topTeam?.Constructor?.name || '—'" :subtitle="(topTeam?.points || 0) + ' pts'" tone="orange" />
         </div>
 
 
@@ -77,108 +77,108 @@
     {
       category: 'Chiffres clés',
       items: [
-        { title: "Année de création", value: '1950', subtitle: '', tone: 'emerald' },
-        { title: 'Nombre total de Grands Prix', value: '1108', subtitle: '', tone: 'cyan' },
-        { title: 'Nombre total de saisons', value: '75', subtitle: '', tone: 'violet' },
-        { title: 'Circuits utilisés', value: '76', subtitle: '', tone: 'lime' },
-        { title: 'Pays hôtes', value: '34', subtitle: '', tone: 'emerald' },
-        { title: 'Pilotes ayant couru', value: '775', subtitle: '', tone: 'cyan' },
-        { title: 'Écuries participantes', value: '170', subtitle: '', tone: 'violet' },
+        { title: "Année de création", value: '1950', subtitle: '', tone: 'green' },
+        { title: 'Nombre total de Grands Prix', value: '1108', subtitle: '', tone: 'yellow' },
+        { title: 'Nombre total de saisons', value: '75', subtitle: '', tone: 'red' },
+        { title: 'Circuits utilisés', value: '76', subtitle: '', tone: 'orange' },
+        { title: 'Pays hôtes', value: '34', subtitle: '', tone: 'green' },
+        { title: 'Pilotes ayant couru', value: '775', subtitle: '', tone: 'yellow' },
+        { title: 'Écuries participantes', value: '170', subtitle: '', tone: 'red' },
       ],
     },
     {
       category: 'Titres et records',
       items: [
-        { title: 'Champions du monde', value: '34', subtitle: '', tone: 'emerald' },
-        { title: 'Pilote le plus titré', value: 'M. Schumacher & L. Hamilton', subtitle: '7 titres', tone: 'cyan' },
-        { title: 'Écurie la plus titrée', value: 'Ferrari', subtitle: '16 titres constructeurs', tone: 'violet' },
-        { title: 'Plus jeune champion', value: 'S. Vettel', subtitle: '23 ans', tone: 'lime' },
-        { title: 'Plus vieux champion', value: 'J. M. Fangio', subtitle: '46 ans', tone: 'emerald' },
-        { title: 'Plus grand écart pour un titre', value: '155 pts', subtitle: 'Vettel 2013', tone: 'cyan' },
-        { title: 'Plus petit écart pour un titre', value: '0,5 pt', subtitle: 'Lauda 1984', tone: 'violet' },
+        { title: 'Champions du monde', value: '34', subtitle: '', tone: 'green' },
+        { title: 'Pilote le plus titré', value: 'M. Schumacher & L. Hamilton', subtitle: '7 titres', tone: 'yellow' },
+        { title: 'Écurie la plus titrée', value: 'Ferrari', subtitle: '16 titres constructeurs', tone: 'red' },
+        { title: 'Plus jeune champion', value: 'S. Vettel', subtitle: '23 ans', tone: 'orange' },
+        { title: 'Plus vieux champion', value: 'J. M. Fangio', subtitle: '46 ans', tone: 'green' },
+        { title: 'Plus grand écart pour un titre', value: '155 pts', subtitle: 'Vettel 2013', tone: 'yellow' },
+        { title: 'Plus petit écart pour un titre', value: '0,5 pt', subtitle: 'Lauda 1984', tone: 'red' },
       ],
     },
     {
       category: 'Victoires et podiums',
       items: [
-        { title: 'Pilote le plus victorieux', value: 'Lewis Hamilton', subtitle: '103 victoires', tone: 'emerald' },
-        { title: 'Écurie la plus victorieuse', value: 'Ferrari', subtitle: '243 victoires', tone: 'cyan' },
-        { title: 'Total des victoires', value: '1108', subtitle: '', tone: 'violet' },
-        { title: 'Pays le plus victorieux', value: 'Royaume-Uni', subtitle: '299 victoires', tone: 'lime' },
-        { title: 'Total des podiums', value: '3324', subtitle: '', tone: 'emerald' },
-        { title: 'Podiums sans victoire', value: 'Nick Heidfeld', subtitle: '13 podiums', tone: 'cyan' },
-        { title: 'Victoires sans titre', value: 'Stirling Moss', subtitle: '16 victoires', tone: 'violet' },
+        { title: 'Pilote le plus victorieux', value: 'Lewis Hamilton', subtitle: '103 victoires', tone: 'green' },
+        { title: 'Écurie la plus victorieuse', value: 'Ferrari', subtitle: '243 victoires', tone: 'yellow' },
+        { title: 'Total des victoires', value: '1108', subtitle: '', tone: 'red' },
+        { title: 'Pays le plus victorieux', value: 'Royaume-Uni', subtitle: '299 victoires', tone: 'orange' },
+        { title: 'Total des podiums', value: '3324', subtitle: '', tone: 'green' },
+        { title: 'Podiums sans victoire', value: 'Nick Heidfeld', subtitle: '13 podiums', tone: 'yellow' },
+        { title: 'Victoires sans titre', value: 'Stirling Moss', subtitle: '16 victoires', tone: 'red' },
       ],
     },
     {
       category: 'Qualifications',
       items: [
-        { title: 'Record de poles', value: 'Lewis Hamilton', subtitle: '104 poles', tone: 'emerald' },
-        { title: 'Écurie avec le plus de poles', value: 'Ferrari', subtitle: '249 poles', tone: 'cyan' },
-        { title: 'Plus jeune poleman', value: 'S. Vettel', subtitle: '21 ans', tone: 'violet' },
-        { title: 'Plus vieux poleman', value: 'G. Farina', subtitle: '47 ans', tone: 'lime' },
-        { title: 'Total des poles', value: '1108', subtitle: '', tone: 'emerald' },
+        { title: 'Record de poles', value: 'Lewis Hamilton', subtitle: '104 poles', tone: 'green' },
+        { title: 'Écurie avec le plus de poles', value: 'Ferrari', subtitle: '249 poles', tone: 'yellow' },
+        { title: 'Plus jeune poleman', value: 'S. Vettel', subtitle: '21 ans', tone: 'red' },
+        { title: 'Plus vieux poleman', value: 'G. Farina', subtitle: '47 ans', tone: 'orange' },
+        { title: 'Total des poles', value: '1108', subtitle: '', tone: 'green' },
       ],
     },
     {
       category: 'Records de tours',
       items: [
-        { title: 'Meilleurs tours pilote', value: 'M. Schumacher', subtitle: '77', tone: 'cyan' },
-        { title: 'Meilleurs tours écurie', value: 'Ferrari', subtitle: '259', tone: 'violet' },
-        { title: 'Tour le plus rapide en course', value: '1:19.525', subtitle: 'Montoya, Monza 2004', tone: 'lime' },
-        { title: 'Tour le plus rapide en qualifs', value: '1:18.887', subtitle: 'Hamilton, Monza 2020', tone: 'emerald' },
+        { title: 'Meilleurs tours pilote', value: 'M. Schumacher', subtitle: '77', tone: 'yellow' },
+        { title: 'Meilleurs tours écurie', value: 'Ferrari', subtitle: '259', tone: 'red' },
+        { title: 'Tour le plus rapide en course', value: '1:19.525', subtitle: 'Montoya, Monza 2004', tone: 'orange' },
+        { title: 'Tour le plus rapide en qualifs', value: '1:18.887', subtitle: 'Hamilton, Monza 2020', tone: 'green' },
       ],
     },
     {
       category: 'Techniques & machines',
       items: [
-        { title: 'Voiture la plus dominante', value: 'Mercedes W11', subtitle: '2020', tone: 'cyan' },
-        { title: 'Moteur le plus victorieux', value: 'Ferrari', subtitle: '243 victoires', tone: 'violet' },
-        { title: 'Motoristes différents', value: '73', subtitle: '', tone: 'lime' },
-        { title: 'Conso moy. par course', value: '≈150 L', subtitle: '', tone: 'emerald' },
-        { title: 'Fournisseurs de pneus', value: '12', subtitle: 'depuis 1950', tone: 'cyan' },
-        { title: 'Pit stop le plus rapide', value: '1.82 s', subtitle: 'Red Bull 2019', tone: 'violet' },
+        { title: 'Voiture la plus dominante', value: 'Mercedes W11', subtitle: '2020', tone: 'yellow' },
+        { title: 'Moteur le plus victorieux', value: 'Ferrari', subtitle: '243 victoires', tone: 'red' },
+        { title: 'Motoristes différents', value: '73', subtitle: '', tone: 'orange' },
+        { title: 'Conso moy. par course', value: '≈150 L', subtitle: '', tone: 'green' },
+        { title: 'Fournisseurs de pneus', value: '12', subtitle: 'depuis 1950', tone: 'yellow' },
+        { title: 'Pit stop le plus rapide', value: '1.82 s', subtitle: 'Red Bull 2019', tone: 'red' },
       ],
     },
     {
       category: 'Géographie & circuits',
       items: [
-        { title: 'Circuit le plus fréquenté', value: 'Monza', subtitle: '73 GP', tone: 'emerald' },
-        { title: 'Circuit le plus rapide', value: 'Monza', subtitle: '≈264 km/h', tone: 'cyan' },
-        { title: 'Circuit le plus lent', value: 'Monaco', subtitle: '≈160 km/h', tone: 'violet' },
-        { title: 'Total des circuits', value: '76', subtitle: '', tone: 'lime' },
-        { title: 'Pays le plus hôte', value: 'Italie', subtitle: '≈103 GP', tone: 'emerald' },
-        { title: 'Premier GP hors-Europe', value: 'Indianapolis 1950', subtitle: 'États-Unis', tone: 'cyan' },
+        { title: 'Circuit le plus fréquenté', value: 'Monza', subtitle: '73 GP', tone: 'green' },
+        { title: 'Circuit le plus rapide', value: 'Monza', subtitle: '≈264 km/h', tone: 'yellow' },
+        { title: 'Circuit le plus lent', value: 'Monaco', subtitle: '≈160 km/h', tone: 'red' },
+        { title: 'Total des circuits', value: '76', subtitle: '', tone: 'orange' },
+        { title: 'Pays le plus hôte', value: 'Italie', subtitle: '≈103 GP', tone: 'green' },
+        { title: 'Premier GP hors-Europe', value: 'Indianapolis 1950', subtitle: 'États-Unis', tone: 'yellow' },
       ],
     },
     {
       category: 'Fiabilité & abandons',
       items: [
-        { title: 'Total des abandons', value: '>16000', subtitle: '', tone: 'violet' },
-        { title: 'Cause la plus fréquente', value: 'Mécanique', subtitle: '', tone: 'lime' },
-        { title: 'Abandons dans une course', value: '18', subtitle: 'Monaco 1996', tone: 'emerald' },
-        { title: 'Écurie la plus fiable', value: 'Mercedes', subtitle: '>90% de fins de course', tone: 'cyan' },
+        { title: 'Total des abandons', value: '>16000', subtitle: '', tone: 'red' },
+        { title: 'Cause la plus fréquente', value: 'Mécanique', subtitle: '', tone: 'orange' },
+        { title: 'Abandons dans une course', value: '18', subtitle: 'Monaco 1996', tone: 'green' },
+        { title: 'Écurie la plus fiable', value: 'Mercedes', subtitle: '>90% de fins de course', tone: 'yellow' },
       ],
     },
     {
       category: 'Autres records',
       items: [
-        { title: 'Course la plus longue', value: 'Canada 2011', subtitle: '4h04', tone: 'violet' },
-        { title: 'Course la plus courte', value: 'Spa 2021', subtitle: '3 min', tone: 'lime' },
-        { title: 'Dépassements record', value: '170', subtitle: 'Chine 2016', tone: 'emerald' },
-        { title: 'Vitesse max en course', value: '372,5 km/h', subtitle: 'Montoya Monza 2005', tone: 'cyan' },
-        { title: 'Pilotes tués en course', value: '52', subtitle: '', tone: 'violet' },
-        { title: 'Introduction du halo', value: '2018', subtitle: 'aucun décès depuis', tone: 'lime' },
-        { title: 'Introduction du DRS', value: '2011', subtitle: '+40% dépassements', tone: 'emerald' },
+        { title: 'Course la plus longue', value: 'Canada 2011', subtitle: '4h04', tone: 'red' },
+        { title: 'Course la plus courte', value: 'Spa 2021', subtitle: '3 min', tone: 'orange' },
+        { title: 'Dépassements record', value: '170', subtitle: 'Chine 2016', tone: 'green' },
+        { title: 'Vitesse max en course', value: '372,5 km/h', subtitle: 'Montoya Monza 2005', tone: 'yellow' },
+        { title: 'Pilotes tués en course', value: '52', subtitle: '', tone: 'red' },
+        { title: 'Introduction du halo', value: '2018', subtitle: 'aucun décès depuis', tone: 'orange' },
+        { title: 'Introduction du DRS', value: '2011', subtitle: '+40% dépassements', tone: 'green' },
       ],
     },
     {
       category: 'Classements cumulés',
       items: [
-        { title: 'Nation la plus titrée', value: 'Royaume-Uni', subtitle: 'pilotes + constructeurs', tone: 'cyan' },
-        { title: 'Écurie la plus prolifique', value: 'Ferrari', subtitle: '~10k points', tone: 'violet' },
-        { title: 'Pilote le plus expérimenté', value: 'Fernando Alonso', subtitle: '380+ GP', tone: 'lime' },
-        { title: 'Circuit le plus disputé', value: 'Monza', subtitle: '73 GP', tone: 'emerald' },
+        { title: 'Nation la plus titrée', value: 'Royaume-Uni', subtitle: 'pilotes + constructeurs', tone: 'yellow' },
+        { title: 'Écurie la plus prolifique', value: 'Ferrari', subtitle: '~10k points', tone: 'red' },
+        { title: 'Pilote le plus expérimenté', value: 'Fernando Alonso', subtitle: '380+ GP', tone: 'orange' },
+        { title: 'Circuit le plus disputé', value: 'Monza', subtitle: '73 GP', tone: 'green' },
       ],
     },
   ]
@@ -393,14 +393,14 @@
             : 'shadow-[0_0_60px_rgba(59,130,246,0.15)]'
         )
       return () => (
-        <div class={["relative rounded-3xl p-4 bg-[#111214] border border-white/10", ring.value] as any}>
+        <div class={["relative rounded-3xl p-4 bg-f1-gray border border-white/10", ring.value] as any}>
           <div class="flex items-start justify-between mb-2">
             <div>
               <h3 class="text-lg font-semibold">{props.title}</h3>
               <p class="text-xs text-zinc-500">{props.subtitle}</p>
             </div>
             <div class="w-6 h-6 rounded-full bg-white/5 grid place-items-center">
-              <span class="w-1.5 h-1.5 rounded-full bg-emerald-400"></span>
+              <span class="w-1.5 h-1.5 rounded-full bg-f1-red"></span>
             </div>
           </div>
           <div class="mt-2">{slots.default?.()}</div>
@@ -414,14 +414,14 @@
     props: { title: String, value: [String, Number] as any, subtitle: String, tone: String },
     setup(props) {
       const toneMap: Record<string, string> = {
-        emerald: 'from-emerald-500/30 to-emerald-400/10',
-        cyan:    'from-cyan-500/30 to-cyan-400/10',
-        violet:  'from-violet-500/30 to-violet-400/10',
-        lime:    'from-lime-400/30 to-lime-300/10',
+        red: 'from-red-500/30 to-red-400/10',
+        orange: 'from-orange-500/30 to-orange-400/10',
+        yellow: 'from-yellow-500/30 to-yellow-400/10',
+        green: 'from-green-500/30 to-green-400/10',
       }
       return () => (
-        <div class="relative rounded-3xl p-5 bg-[#111214] border border-white/10 overflow-hidden">
-          <div class={[`absolute inset-0 opacity-40 blur-2xl pointer-events-none bg-gradient-to-br ${toneMap[props.tone || 'emerald']}`] as any}></div>
+        <div class="relative rounded-3xl p-5 bg-f1-gray border border-white/10 overflow-hidden">
+          <div class={[`absolute inset-0 opacity-40 blur-2xl pointer-events-none bg-gradient-to-br ${toneMap[props.tone || 'green']}`] as any}></div>
           <div class="relative">
             <p class="text-sm text-zinc-400">{props.title}</p>
             <p class="text-3xl font-extrabold tracking-tight mt-1">{props.value as any}</p>


### PR DESCRIPTION
## Summary
- restyle dashboard header and KPI cards with F1 color palette (red, yellow, green, orange)
- update card components to use F1 theme colors and gradients

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b82a173aa8832c97b3ed55059084fe